### PR TITLE
Test rework

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,4 @@
+export iii_acc__TEST_NAME='test'
+export iii_acc__TEST_BARCODE='test'
+#optional
+export iii_acc_FIXTURE_DIR='fixtures'

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 .DS_Store
+.env
+fixtures/*

--- a/test_account.py
+++ b/test_account.py
@@ -37,6 +37,7 @@ def test_login():
         sess.login()
         sess.logout()
 
+
 #For now - this is expected to fail.
 @pytest.mark.xfail
 @bul_vcr.use_cassette('login-bad.yaml')
@@ -51,6 +52,7 @@ def test_login_bad():
             exception = repr(e)
         assert exception == 'Login failed.'
 
+
 @bul_vcr.use_cassette('checkouts.yaml')
 def test_get_checkouts():
     with vcr.use_cassette('../fixtures/checkouts.yaml', filter_post_data_parameters=['name', 'code']):
@@ -59,6 +61,7 @@ def test_get_checkouts():
         checkouts = sess.get_checkouts()
         assert "Z695.Z8 F373 2010" in [i['call_number'] for i in checkouts]
         sess.logout()
+
 
 @bul_vcr.use_cassette('grad-hold-open-circ.yaml')
 def test_complete_hold():
@@ -83,6 +86,7 @@ def test_get_holds():
         existing_holds = sess.get_holds()
         assert existing_holds[0]['key'] == 'canceli11425642x00'
         sess.logout()
+
 
 @bul_vcr.use_cassette('cancel-single-hold.yaml')
 def test_cancel_hold():
@@ -109,7 +113,6 @@ def test_denied_hold():
         assert hold['confirmed'] == False
         assert hold['message'] == "No requestable items are available"
         sess.logout()
-
 
 
 if __name__ == "__main__":

--- a/test_account.py
+++ b/test_account.py
@@ -1,8 +1,12 @@
+
+import json
+import os
+import time
+
+import pytest
 import vcr
-import json, os
 
 from iii_account import IIIAccount
-import time
 
 name, barcode = ( os.environ[u'iii_acc__TEST_NAME'], os.environ[u'iii_acc__TEST_BARCODE'] )
 
@@ -15,6 +19,17 @@ console_handler = logging.StreamHandler()
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 
+# Custom VCR config.
+bul_vcr = vcr.VCR(
+    cassette_library_dir = os.environ.get('iii_acc_FIXTURE_DIR', 'fixtures'),
+    filter_post_data_parameters=['name', 'code'],
+    # This prevents new HTTP requests.  Comment or remove to record
+    # new fixtures.
+    record_mode = 'none',
+)
+
+
+@bul_vcr.use_cassette('login-out.yaml')
 def test_login():
     with vcr.use_cassette('../fixtures/login-out.yaml', filter_post_data_parameters=['name', 'code']):
         sess = IIIAccount(name, barcode)
@@ -22,6 +37,9 @@ def test_login():
         sess.login()
         sess.logout()
 
+#For now - this is expected to fail.
+@pytest.mark.xfail
+@bul_vcr.use_cassette('login-bad.yaml')
 def test_login_bad():
     with vcr.use_cassette('../fixtures/login-bad.yaml', filter_post_data_parameters=['name', 'code']):
         ( name, barcode ) = ( 'foo', 'bar' )
@@ -33,6 +51,7 @@ def test_login_bad():
             exception = repr(e)
         assert exception == 'Login failed.'
 
+@bul_vcr.use_cassette('checkouts.yaml')
 def test_get_checkouts():
     with vcr.use_cassette('../fixtures/checkouts.yaml', filter_post_data_parameters=['name', 'code']):
         sess = IIIAccount(name, barcode)
@@ -41,6 +60,7 @@ def test_get_checkouts():
         assert "Z695.Z8 F373 2010" in [i['call_number'] for i in checkouts]
         sess.logout()
 
+@bul_vcr.use_cassette('grad-hold-open-circ.yaml')
 def test_complete_hold():
     with vcr.use_cassette('../fixtures/grad-hold-open-circ.yaml', filter_post_data_parameters=['name', 'code']):
         sess = IIIAccount(name, barcode)
@@ -54,6 +74,8 @@ def test_complete_hold():
         print json.dumps(hold, indent=2)
         sess.logout()
 
+
+@bul_vcr.use_cassette('get-holds.yaml')
 def test_get_holds():
     with vcr.use_cassette('../fixtures/get-holds.yaml', filter_post_data_parameters=['name', 'code']):
         sess = IIIAccount(name, barcode)
@@ -62,6 +84,7 @@ def test_get_holds():
         assert existing_holds[0]['key'] == 'canceli11425642x00'
         sess.logout()
 
+@bul_vcr.use_cassette('cancel-single-hold.yaml')
 def test_cancel_hold():
     cancel_key = 'canceli11425642x00'
     with vcr.use_cassette('../fixtures/cancel-single-hold.yaml', filter_post_data_parameters=['name', 'code']):
@@ -72,6 +95,7 @@ def test_cancel_hold():
         sess.logout()
 
 
+@bul_vcr.use_cassette('undergrad-hold-denied-open-circ.yaml')
 def test_denied_hold():
     with vcr.use_cassette('../fixtures/undergrad-hold-denied-open-circ.yaml', filter_post_data_parameters=['name', 'code']):
         sess = IIIAccount(name, barcode)
@@ -89,4 +113,4 @@ def test_denied_hold():
 
 
 if __name__ == "__main__":
-    test_cancel_hold()
+    raise Exception("Run with py.test.")


### PR DESCRIPTION
- add sample .env file
- checks env for fixtures directory or uses ./fixtures
- sets custom vcrpy setup to resolve fixture dir and reduce boilerplate.
- expects `test_login_bad` to fail.  Can remove when that code is written.  
